### PR TITLE
Allows for setting map styles based on game data

### DIFF
--- a/src/MapSingle.jsx
+++ b/src/MapSingle.jsx
@@ -51,7 +51,7 @@ const MapSingle = ({ match }) => {
         rotation: game.info.orientation === "horizontal" ? 0 : 90
       }}
     >
-      <div className="map">
+      <div className="map" style={game.map.style} >
         <Svg width={totalWidth} height={totalHeight}>
           <Title game={game} variation={variation} />
           <Map game={game} variation={variation} />

--- a/src/atoms/Hex.jsx
+++ b/src/atoms/Hex.jsx
@@ -5,7 +5,7 @@ import * as R from "ramda";
 import HexContext from "../context/HexContext";
 
 const Hex = ({ color, border, transparent }) => {
-  let fill = (border || transparent ? "transparent" : (R.isNil(colors[color]) ? color : colors[color]));
+  let fill = (border ? "transparent" : (R.isNil(colors[color]) ? color : colors[color]));
   let stroke = border ? colors["black"] : "none";
 
   return (
@@ -15,6 +15,7 @@ const Hex = ({ color, border, transparent }) => {
           <polygon
             points="-86.6025,0 -43.30125,-75 43.30125,-75 86.6025,0 43.30125,75 -43.30125,75"
             fill={fill}
+            opacity={transparent || 1}
             strokeLinecap="round"
             strokeLinejoin="bevel"
             strokeWidth="2"

--- a/src/data/games/1834.js
+++ b/src/data/games/1834.js
@@ -9,7 +9,7 @@ const game = {
     width: 150,
     color_10: "orange",
     titleX: 50,
-    hexCoords: true
+    hexCoords: true,
   },
 
   // Extra Tokens
@@ -1203,7 +1203,7 @@ const game = {
           "O12",
         ]
       }
-    ]
+    ],
   }
 };
 


### PR DESCRIPTION
With this you can set the background styles(and any other styles)
in the game data file. This allows for an image to be set for the
background, then you can set the transparency(using 0-1) and it
will set the opacity at that level so you can see the background
image.