### PR TITLE
Moved <Color> component up to solve z-index issue

### DIFF
--- a/src/cards/Train.jsx
+++ b/src/cards/Train.jsx
@@ -38,10 +38,14 @@ const Train = ({ train }) => {
   return (
     <div className="cutlines">
       <div className="card train">
+        <Color>
+          {c => (
+            <div className="train__hr" style={{ backgroundColor: c(color) }} />
+          )}
+        </Color>
         <div className="train__price">{price}</div>
         <div className="train__description">{description}</div>
         <div className="train__notes">{notes}</div>
-          <Color>{c => (<div className="train__hr" style={{ backgroundColor: c(color) }} />)}</Color>
         <div className="train__name">{name}</div>
       </div>
     </div>


### PR DESCRIPTION
# Details

This MR includes a small change which solves a z-index issue with the train's phase colors. Before the color was drawn last and covered up the price, now since the color is drawn first the text will be drawn on top and avoid the z-index issue.

# Screenshots

Before:
![Screenshot from 2019-03-08 15-08-29](https://user-images.githubusercontent.com/691304/54055942-3031ce80-41b4-11e9-9d3a-988d2efb9fa8.png)

After:
![Screenshot from 2019-03-08 15-08-56](https://user-images.githubusercontent.com/691304/54055945-34f68280-41b4-11e9-8cba-e18f18de14f5.png)
