### PR TITLE
Fix for label on Montevideo now showing

### DIFF
--- a/src/data/games/1868.js
+++ b/src/data/games/1868.js
@@ -1337,12 +1337,23 @@ const game = {
       },
       {
         color: "gray",
+        labels: [
+          {
+            label: "Monte-",
+            size: 10,
+            angle: 180,
+            percent: 0.94
+          },
+          {
+            label: "video",
+            size: 10,
+            angle: 180,
+            percent: 0.81
+          }
+        ],
         cities: [
           {
-            size: 4,
-            name: {
-              name: "Montevideo"
-            }
+            size: 4
           }
         ],
         track: [


### PR DESCRIPTION
# Details

Just a quick fix based on Kelsin's tip on getting a label to appear on a 4-city hex. Had to put a break in, but that's also how it appears on the published map itself.

# Screenshots

![Screenshot from 2019-03-16 10-40-53](https://user-images.githubusercontent.com/691304/54477702-1c9bee80-47d8-11e9-9fc0-8cf3f2791759.png)
