### PR TITLE
Add even-row indentation to tile layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -57,12 +57,8 @@ body {
   overflow: hidden;
 }
 
-.tileSheet div.row svg {
-  margin: 0.125in 0.125in 0 0;
-}
-
-.tileSheet div.row svg:last-child {
-  margin: 0.125in 0 0 0;
+.tileSheet div.row:nth-child(even) {
+    padding-left: 1.73205in;
 }
 
 .tileSheet svg {


### PR DESCRIPTION
And remove margins on tiles, this makes it far easier to cut the tiles
out as you only need to make straight cuts along the edges of the tiles.

Signed-off-by: Tobias Sjöndin <tobias.sjondin@gmail.com>