### PR TITLE
Replaced 1834.json

### DIFF
--- a/src/data/games/1834.json
+++ b/src/data/games/1834.json
@@ -6,48 +6,55 @@
     "background": "gray",
     "orientation": "horizontal",
     "titleX": 50,
-    "currency": "EUR"
+    "currency": "BEF"
   },
   "links": {
     "bgg": "https://www.boardgamegeek.com/boardgame/253320/1834"
   },
+  
+   "colors": 
+  {
+		"luxpurple": "#bb34ed",
+		"mongreen": "#43a036",	  
+  "companies": 
+	 	{
+	  	"luxpurple": "#bb34ed",
+  		"mongreen": "#43a036"
+		}
+  },
+  
   "tokens": [
     "Round"
   ],
   "ipo": true,
-  "bank": "$7,500",
+  "bank": "7,500 fr.",
+
   "players": [
     {
       "number": 3,
       "certLimit": 13,
-      "capital": "$700"
+      "capital": "700 fr."
     },
     {
       "number": 4,
       "certLimit": 10,
-      "capital": "$550"
+      "capital": "550 fr."
     },
     {
       "number": 5,
       "certLimit": 8,
-      "capital": "$440"
-    }
-  ],
-  "companies": [
+      "capital": "440 fr."
+    }  ],
+"companies": [
     {
       "name": "Luxembourg Railway",
       "abbrev": "LUX",
-      "tokens": [
-        "Free",
-        "$40",
-        "$70",
-        "$100"
-      ],
-      "color": "purple",
+      "tokens": ["Home", "40 fr.", "70 fr.", "100 fr."],
+      "token": {"type":"bar", "colors": ["luxpurple"]},
       "shares": [
         {
           "quantity": 1,
-          "label": "President's Certificate",
+          "label": "President Share",
           "percent": 20,
           "shares": 2
         },
@@ -61,16 +68,12 @@
     {
       "name": "Ostend Railway",
       "abbrev": "OST",
-      "tokens": [
-        "Home",
-        "$40",
-        "$100"
-      ],
-      "color": "blue",
+      "tokens": ["Home", "40 fr.", "100 fr."],
+      "token": {"type":"bar", "colors": ["cyan"]},
       "shares": [
         {
           "quantity": 1,
-          "label": "President's Certificate",
+          "label": "President Share",
           "percent": 20,
           "shares": 2
         },
@@ -84,15 +87,12 @@
     {
       "name": "Antwerp Railway",
       "abbrev": "ANT",
-      "tokens": [
-        "Home",
-        "$100"
-      ],
-      "color": "yellow",
+      "tokens": ["Home", "100 fr."],
+      "token": {"type":"bar", "colors": ["yellow"]},
       "shares": [
         {
           "quantity": 1,
-          "label": "President's Certificate",
+          "label": "President Share",
           "percent": 20,
           "shares": 2
         },
@@ -106,16 +106,12 @@
     {
       "name": "Liege Railway",
       "abbrev": "LIE",
-      "tokens": [
-        "Home",
-        "$40",
-        "$100"
-      ],
-      "color": "red",
+      "tokens": ["Home", "40 fr.", "100 fr."],
+      "token": {"type":"bar", "colors": ["red"]},
       "shares": [
         {
           "quantity": 1,
-          "label": "President's Certificate",
+          "label": "President Share",
           "percent": 20,
           "shares": 2
         },
@@ -129,16 +125,12 @@
     {
       "name": "Mons Railway",
       "abbrev": "MON",
-      "tokens": [
-        "Home",
-        "$40",
-        "$100"
-      ],
-      "color": "green",
+      "tokens": ["Home", "40 fr.", "100 fr."],
+      "token": {"type":"bar", "colors": ["mongreen"]},
       "shares": [
         {
           "quantity": 1,
-          "label": "President's Certificate",
+          "label": "President Share",
           "percent": 20,
           "shares": 2
         },
@@ -150,13 +142,15 @@
       ]
     }
   ],
+
   "trains": [
     {
       "name": "2",
       "quantity": 5,
-      "price": "$80",
+      "price": "80 fr.",
       "color": "yellow",
-      "info": [
+      "description": "Runs a route between 2 adjacent stops, counting them both towards the value of its run",
+		"info": [
         {
           "color": "blue",
           "note": "Rusted by 4"
@@ -166,9 +160,10 @@
     {
       "name": "3",
       "quantity": 4,
-      "price": "$180",
+      "price": "180 fr.",
       "color": "green",
-      "info": [
+      "description": "Runs a route consisting of 3 consecutive stops, counting them all towards the value of its run",
+		"info": [
         {
           "color": "brown",
           "note": "Rusted by 5"
@@ -178,8 +173,9 @@
     {
       "name": "4",
       "quantity": 3,
-      "price": "$300",
+      "price": "300 fr.",
       "color": "blue",
+	  "description": "Runs a route consisting of 4 consecutive stops, counting them all towards the value of its run",
       "info": [
         {
           "color": "red",
@@ -190,21 +186,25 @@
     {
       "name": "5",
       "quantity": 2,
-      "price": "$450",
+      "price": "450 fr.",
       "color": "brown",
-      "info": [
+      "description": "Runs a route consisting of 5 consecutive stops, counting them all towards the value of its run",
+		"info": [
         {
           "color": "gray",
           "note": "Permanent"
         }
       ]
     },
+	
+	
     {
       "name": "6",
       "quantity": 2,
-      "price": "$630",
+      "price": "630 fr.",
       "color": "red",
-      "info": [
+      "description": "Runs a route consisting of 6 consecutive stops, counting them all towards the value of its run",
+		"info": [
         {
           "color": "gray",
           "note": "Permanent"
@@ -214,9 +214,9 @@
     {
       "name": "2T",
       "quantity": 5,
-      "price": "$750",
+      "price": "750 fr.",
       "color": "gray",
-      "description": "Runs between 2 cities, counts all towns, doubles one city.",
+      "description": "Runs between 2 cities, counts all towns, doubles one city",
       "info": [
         {
           "color": "gray",
@@ -225,44 +225,51 @@
       ]
     }
   ],
+
   "privates": [
     {
       "name": "Ostend Port Society",
-      "price": "$20",
-      "revenue": "$5",
-      "description": "Increase runs to Ostend port(blue offboard) by $20. Can be sold in YELLOW and GREEN."
+      "price": "20 fr.",
+      "revenue": "5 fr.",
+      "description": "Increase runs to Ostend port(blue offboard) by 20 francs. Can be sold in YELLOW and GREEN."
     },
     {
       "name": "De Kempen Coal Company",
-      "price": "$40",
-      "revenue": "$10",
-      "description": "Owning corporation may place a track tile on a mountain hex at half cost. Can be sold in YELLOW and GREEN."
+      "price": "40 fr.",
+      "revenue": "10 fr.",
+      "description":
+        "Owning corporation may place a track tile on a mountain hex at half cost. Can be sold in YELLOW and GREEN."
     },
     {
       "name": "Burbach Foundry",
-      "price": "$70",
-      "revenue": "$15",
-      "description": "Owning corporation may upgrade an additional track tile, the Luxembourg city tile(hexes N11 and M10), from YELLOW to GREEN. THis is in addition to it's normal placement. Can be sold in GREEN."
+      "price": "70 fr.",
+      "revenue": "15 fr.",
+      "description":
+        "Owning corporation may upgrade an additional track tile, the Luxembourg city tile(hexes N11 and M10), from YELLOW to GREEN. THis is in addition to it's normal placement. Can be sold in GREEN phase."
     },
     {
       "name": "MNBS SNCF Electrification",
-      "price": "$100",
-      "revenue": "$0",
-      "description": "At the start of the silver phase after all 4 trains have been removed, the player holding this private must place a 2T train on a railraod's charter. This costs nothing and can be used immediately. MAY NOT BE SOLD TO A RAILROAD."
+      "price": "100 fr.",
+      "revenue": "0 fr.",
+      "description":
+        "MAY NOT BE SOLD TO A RAILROAD. At the start of the silver phase after all 4 trains have been removed, the player holding this private must place a 2T train on a railraod's charter. This costs nothing and can be used immediately."
     },
     {
       "name": "Cockerill Locomotive Company",
-      "price": "$120",
-      "revenue": "$20",
-      "description": "Allows owning railroad to purchase a train at half price, this closes the private. Can be sold in YELLOW and GREEN."
+      "price": "120 fr.",
+      "revenue": "20 fr.",
+      "description":
+        "Allows owning railroad to purchase a train at half price, this closes the private. Can be sold during the Yellow and the GREEN phase."
     },
     {
       "name": "Albert Canal Corporation",
-      "price": "$150",
-      "revenue": "$25",
-      "description": "No other ability. Closes in BROWN or if track connects Antwerp to Liege by any route or manner regardless of tokens. Can be sold in GREEN."
+      "price": "150 fr.",
+      "revenue": "25 fr.",
+      "description":
+        " No other ability. Closes in BROWN or if track connects Antwerp to Liege by any route or manner regardless of tokens. Can be sold in the GREEN phase."
     }
   ],
+
   "phases": [
     {
       "name": "2",
@@ -693,7 +700,7 @@
     "legend": [
       {
         "color": "yellow",
-        "description": "Shares of this corporation do not count toward the certificate limit",
+        "description": "shares of this corporation do not count toward the certificate limit",
         "icon": "certificate"
       },
       {
@@ -768,10 +775,13 @@
               "name": "Ostend"
             },
             "companies": [
-              {
-                "label": "OST",
-                "color": "blue"
-              }
+{
+  "label": "OST",
+  "token": {
+    "type": "bar",
+    "colors": ["cyan"]
+  }
+}
             ]
           }
         ],
@@ -789,7 +799,10 @@
             "companies": [
               {
                 "label": "MON",
-                "color": "green"
+  "token": {
+    "type": "bar",
+    "colors": ["mongreen"]
+  }
               }
             ]
           }
@@ -808,7 +821,10 @@
             "companies": [
               {
                 "label": "LIE",
-                "color": "red"
+   "token": {
+    "type": "bar",
+    "colors": ["red"]
+  }
               }
             ]
           }
@@ -956,7 +972,10 @@
             "companies": [
               {
                 "label": "LUX",
-                "color": "purple"
+  "token": {
+    "type": "bar",
+    "colors": ["luxpurple"]
+  }
               }
             ]
           }
@@ -1017,7 +1036,10 @@
             "companies": [
               {
                 "label": "ANT",
-                "color": "yellow"
+  "token": {
+    "type": "bar",
+    "colors": ["yellow"]
+  }
               }
             ]
           }
@@ -1394,7 +1416,7 @@
       {
         "color": "plain",
         "water": {
-          "cost": "$40"
+          "cost": "40 fr."
         },
         "hexes": [
           "F7",
@@ -1411,7 +1433,7 @@
         ],
         "water": {
           "percent": 0.5,
-          "cost": "30",
+          "cost": "30 fr.",
           "size": "small"
         },
         "hexes": [
@@ -1422,7 +1444,7 @@
       {
         "color": "plain",
         "water": {
-          "cost": "$20"
+          "cost": "20 fr."
         },
         "hexes": [
           "D11",
@@ -1442,7 +1464,7 @@
           }
         ],
         "water": {
-          "cost": "$20",
+          "cost": "20 fr.",
           "percent": 0.6
         },
         "hexes": [
@@ -1452,7 +1474,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$120"
+          "cost": "120 fr."
         },
         "hexes": [
           "M8"
@@ -1461,7 +1483,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$100"
+          "cost": "100 fr."
         },
         "hexes": [
           "L9"
@@ -1470,7 +1492,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$80"
+          "cost": "80 fr."
         },
         "hexes": [
           "L7"
@@ -1479,7 +1501,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$60"
+          "cost": "60 fr."
         },
         "hexes": [
           "K10",
@@ -1489,7 +1511,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$50"
+          "cost": "50 fr."
         },
         "hexes": [
           "K12"
@@ -1498,7 +1520,7 @@
       {
         "color": "plain",
         "mountain": {
-          "cost": "$40"
+          "cost": "40 fr."
         },
         "hexes": [
           "L5"


### PR DESCRIPTION
Updated presentation to use native currency (hard typed for now) and to align colours and token types with RailsOnBoards 1834 upgrade kit.

Text descriptions fixed, as per previous updates. Train descriptions present.