### PR TITLE
Fix 4T and 6T colors and $30 water hexes in 1834.

### DIFF
--- a/src/data/games/1834.json
+++ b/src/data/games/1834.json
@@ -179,10 +179,10 @@
       "name": "4",
       "quantity": 3,
       "price": "$300",
-      "color": "blue",
+      "color": "green",
       "info": [
         {
-          "color": "red",
+          "color": "gray",
           "note": "Rusted by 6"
         }
       ]
@@ -203,7 +203,7 @@
       "name": "6",
       "quantity": 2,
       "price": "$630",
-      "color": "red",
+      "color": "gray",
       "info": [
         {
           "color": "gray",
@@ -1411,7 +1411,7 @@
         ],
         "water": {
           "percent": 0.5,
-          "cost": "30",
+          "cost": "$30",
           "size": "small"
         },
         "hexes": [


### PR DESCRIPTION
4T should be in a green phase and rusted by 6T, starting gray phase. 6T starts gray phase. Add "$" to $30 water hexes.