### PR TITLE
Update 1867 to match AAG version

### DIFF
--- a/src/data/games/1867.json
+++ b/src/data/games/1867.json
@@ -862,9 +862,12 @@
       },
       {
         "color": "plain",
-        "water": {
-          "cost": "$20"
-        },
+        "terrain": [
+          {
+            "type": "river",
+            "cost": "$20"
+          }
+        ],
         "hexes": [
           "K11"
         ]
@@ -1070,11 +1073,14 @@
       },
       {
         "color": "plain",
-        "water": {
-          "angle": 0,
-          "percent": 0.7,
-          "cost": "$20"
-        },
+        "terrain": [
+          {
+            "type": "river",
+            "cost": "$20",
+            "angle": 0,
+            "percent": 0.7
+          }
+        ],
         "labels": [
           {
             "label": "Y",

--- a/src/data/games/1867.json
+++ b/src/data/games/1867.json
@@ -482,6 +482,118 @@
       "color": "white",
       "tokens": ["", "", "", "", "", "", "", ""],
       "shares": []
+    },
+    {
+      "name": "Buffalo, Brantford, and Goderich",
+      "minor": true,
+      "abbrev": "BBG",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Brockville and Ottawa",
+      "minor": true,
+      "abbrev": "BO",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Canada Southern",
+      "minor": true,
+      "abbrev": "CS",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Credit Valley Railway",
+      "minor": true,
+      "abbrev": "CV",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Kingston and Pembroke",
+      "minor": true,
+      "abbrev": "KP",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "London and Port Stanley",
+      "minor": true,
+      "abbrev": "LPS",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Ottawa and Prescott",
+      "minor": true,
+      "abbrev": "OP",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "St. Lawrence and Atlantic",
+      "minor": true,
+      "abbrev": "SLA",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Toronto, Grey, and Bruce",
+      "minor": true,
+      "abbrev": "TGB",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Toronto and Nipissing",
+      "minor": true,
+      "abbrev": "TN",
+      "tokens": [ "" ],
+      "color": "yellow"
+    },
+    {
+      "name": "Algoma Eastern Railway",
+      "minor": true,
+      "abbrev": "TN",
+      "tokens": [ "" ],
+      "color": "green"
+    },
+    {
+      "name": "Canada Atlantic Railway",
+      "minor": true,
+      "abbrev": "CA",
+      "tokens": [ "" ],
+      "color": "green"
+    },
+    {
+      "name": "New York and Ottawa",
+      "minor": true,
+      "abbrev": "NYO",
+      "tokens": [ "" ],
+      "color": "green"
+    },
+    {
+      "name": "Pere Marquette Railway",
+      "minor": true,
+      "abbrev": "PM",
+      "tokens": [ "" ],
+      "color": "green"
+    },
+    {
+      "name": "Quebec and Lake St. John",
+      "minor": true,
+      "abbrev": "QLS",
+      "tokens": [ "" ],
+      "color": "green"
+    },
+    {
+      "name": "Toronto, Hamilton and Buffalo",
+      "minor": true,
+      "abbrev": "THB",
+      "tokens": [ "" ],
+      "color": "green"
     }
   ],
   "phases": [

--- a/src/data/games/1867.json
+++ b/src/data/games/1867.json
@@ -1,8 +1,11 @@
 {
   "info": {
     "title": "1867",
+    "subtitle": "The Railways of Canada",
     "designer": "Ian Wilson",
     "background": "water",
+    "extraTokens": 1,
+    "extraHomeTokens": 0,
     "orientation": "horizontal",
     "titleX": 1200,
     "titleY": 1200,
@@ -16,33 +19,28 @@
   "tokens": [
     "Round"
   ],
-  "ipo": true,
-  "bank": "¥7,000",
+  "ipo": false,
+  "bank": "$15,000",
   "players": [
     {
-      "number": 2,
-      "certLimit": 25,
-      "capital": "¥420"
-    },
-    {
       "number": 3,
-      "certLimit": 19,
-      "capital": "¥420"
+      "certLimit": 21,
+      "capital": "$420"
     },
     {
       "number": 4,
-      "certLimit": 14,
-      "capital": "¥420"
+      "certLimit": 16,
+      "capital": "$315"
     },
     {
       "number": 5,
-      "certLimit": 12,
-      "capital": "¥390"
+      "certLimit": 13,
+      "capital": "$252"
     },
     {
       "number": 6,
       "certLimit": 11,
-      "capital": "¥390"
+      "capital": "$210"
     }
   ],
   "pools": [
@@ -50,48 +48,53 @@
       "name": "Bank Pool",
       "notes": [
         {
-          "color": "blue",
-          "note": "Shares in the market pay dividends to the corporation"
-        },
-        {
           "color": "purple",
           "icon": "exclamation",
           "note": "No more than 50% of a corporation's shares may be in the market at any time"
-        },
-        {
-          "color": "red",
-          "icon": "times",
-          "note": "Shares cannot be sold during the first stock round"
         }
       ]
     }
   ],
   "rounds": [
     {
-      "name": "OR3",
-      "color": "brown"
+      "name": "SR",
+      "color": "white"
     },
     {
-      "name": "OR2",
-      "color": "green"
+      "name": "MR",
+      "color": "gray"
     },
     {
       "name": "OR1",
-      "color": "yellow"
+      "color": "water"
     },
     {
-      "name": "SR",
+      "name": "MR",
       "color": "gray"
+    },
+    {
+      "name": "OR2",
+      "color": "water"
     }
   ],
   "turns": [
     {
       "name": "Stock Round",
       "steps": [
+        "Sell any number of certificates",
         "Buy one certificate",
-        "Sell any number of certificates"
+        "OR Auction a minor company",
+        "OR Start a public company (starting in phase 4)"
       ],
-      "ordered": false
+      "ordered": true
+    },
+    {
+      "name": "Merge Round",
+      "steps": [
+        "Convert a minor company to a major",
+        "Merge two or more minor companies to form a major company"
+      ],
+      "ordered": true
     },
     {
       "name": "Operating Round",
@@ -106,24 +109,10 @@
     }
   ],
   "stock": {
-    "type": "2D",
+    "type": "1D",
     "par": {
-      "values": [
-        100,
-        90,
-        80,
-        75,
-        70,
-        65
-      ]
     },
     "movement": {
-      "up": [
-        "Sold out"
-      ],
-      "down": [
-        "Every share sold"
-      ],
       "left": [
         "Withheld revenue"
       ],
@@ -132,253 +121,69 @@
       ]
     },
     "market": [
-      [
-        {
-          "label": "75",
-          "arrow": "down"
-        },
-        80,
-        90,
-        {
-          "label": "100",
-          "par": true
-        },
-        110,
-        125,
-        140,
-        155,
-        175,
-        200,
-        225,
-        255,
-        285,
-        315,
-        350
-      ],
-      [
-        {
-          "label": "70",
-          "arrow": "down"
-        },
-        75,
-        80,
-        {
-          "label": "90",
-          "par": true
-        },
-        100,
-        110,
-        125,
-        140,
-        155,
-        175,
-        200,
-        225,
-        255,
-        285,
-        {
-          "label": "315",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "65",
-          "arrow": "down"
-        },
-        70,
-        75,
-        {
-          "label": "80",
-          "par": true
-        },
-        90,
-        100,
-        110,
-        125,
-        140,
-        155,
-        175,
-        {
-          "label": "200",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "60",
-          "arrow": "down"
-        },
-        65,
-        70,
-        {
-          "label": "75",
-          "par": true
-        },
-        80,
-        90,
-        100,
-        110,
-        125,
-        {
-          "label": "140",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "55",
-          "arrow": "down"
-        },
-        60,
-        65,
-        {
-          "label": "70",
-          "par": true
-        },
-        75,
-        80,
-        90,
-        {
-          "label": "100",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "50",
-          "legend": 0,
-          "arrow": "down"
-        },
-        55,
-        60,
-        {
-          "label": "65",
-          "par": true
-        },
-        70,
-        75,
-        {
-          "label": "80",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "45",
-          "legend": 0,
-          "arrow": "down"
-        },
-        {
-          "label": "50",
-          "legend": 0
-        },
-        55,
-        60,
-        65,
-        {
-          "label": "70",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "40",
-          "legend": 0,
-          "arrow": "down"
-        },
-        {
-          "label": "45",
-          "legend": 0
-        },
-        {
-          "label": "50",
-          "legend": 0
-        },
-        55,
-        {
-          "label": "60",
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "30",
-          "legend": 1,
-          "arrow": "down"
-        },
-        {
-          "label": "40",
-          "legend": 0
-        },
-        {
-          "label": "45",
-          "legend": 0
-        },
-        {
-          "label": "50",
-          "legend": 0,
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "20",
-          "legend": 1,
-          "arrow": "down"
-        },
-        {
-          "label": "30",
-          "legend": 1
-        },
-        {
-          "label": "40",
-          "legend": 0
-        },
-        {
-          "label": "45",
-          "legend": 0,
-          "arrow": "up"
-        }
-      ],
-      [
-        {
-          "label": "10",
-          "legend": 1
-        },
-        {
-          "label": "20",
-          "legend": 1
-        },
-        {
-          "label": "30",
-          "legend": 1
-        },
-        {
-          "label": "40",
-          "legend": 0,
-          "arrow": "up"
-        }
-      ]
+      35,
+      40,
+      45,
+      50,
+      55,
+      60,
+      65,
+      70,
+      80,
+      90,
+      100,
+      110,
+      120,
+      135,
+      150,
+      165,
+      180,
+      200,
+      220,
+      245,
+      270,
+      300,
+      330,
+      360,
+      400,
+      440,
+      490,
+      540
     ],
-    "legend": [
+    "limits": [
       {
-        "color": "cyan",
-        "description": "Shares of this corporation do not count toward the certificate limit",
-        "icon": "certificate"
+        "color": "brown",
+        "description": "Minor companies may start here",
+        "min": 50,
+        "max": 135
       },
       {
-        "color": "blue",
-        "description": "Players may own more than 60% of this corporation",
-        "icon": "percentage"
+        "color": "red",
+        "description": "Any company may start here",
+        "min": 70,
+        "max": 135
+      },
+      {
+        "color": "yellow",
+        "description": "Minor companies may convert here",
+        "min": 70,
+        "max": 135
+      },
+      {
+        "color": "purple",
+        "description": "Only Public Companies may start here",
+        "min": 150,
+        "max": 200
       }
+    ],
+    "legend": [
     ]
   },
   "trains": [
     {
       "name": "2",
-      "quantity": 6,
-      "price": "¥80",
+      "quantity": 10,
+      "price": "$100",
       "color": "yellow",
       "info": [
         {
@@ -389,8 +194,8 @@
     },
     {
       "name": "3",
-      "quantity": 5,
-      "price": "¥180",
+      "quantity": 7,
+      "price": "$225",
       "color": "green",
       "info": [
         {
@@ -402,19 +207,19 @@
     {
       "name": "4",
       "quantity": 4,
-      "price": "¥300",
+      "price": "$350",
       "color": "green",
       "info": [
         {
           "color": "brown",
-          "note": "Rusted by D"
+          "note": "Rusted by 8"
         }
       ]
     },
     {
       "name": "5",
-      "quantity": 3,
-      "price": "¥450",
+      "quantity": 4,
+      "price": "$550",
       "color": "brown",
       "info": [
         {
@@ -426,7 +231,7 @@
     {
       "name": "6",
       "quantity": 2,
-      "price": "¥630",
+      "price": "$650",
       "color": "brown",
       "info": [
         {
@@ -436,11 +241,46 @@
       ]
     },
     {
-      "name": "D",
-      "quantity": 9,
-      "price": "¥1100",
+      "name": "7",
+      "quantity": 2,
+      "price": "$800",
       "color": "brown",
-      "description": "Cost ¥800 when trading in a 4T, 5T or 6T",
+      "info": [
+        {
+          "color": "yellow",
+          "note": "Permanent"
+        }
+      ]
+    },
+    {
+      "name": "8",
+      "quantity": 6,
+      "price": "$1000",
+      "color": "gray",
+      "info": [
+        {
+          "color": "yellow",
+          "note": "Permanent"
+        }
+      ]
+    },
+    {
+      "name": "2+2",
+      "quantity": 6,
+      "price": "$600",
+      "color": "gray",
+      "info": [
+        {
+          "color": "yellow",
+          "note": "Permanent"
+        }
+      ]
+    },
+    {
+      "name": "5+5E",
+      "quantity": 7,
+      "price": "$1500",
+      "color": "gray",
       "info": [
         {
           "color": "yellow",
@@ -448,15 +288,41 @@
         }
       ]
     }
+
+
   ],
   "companies": [
     {
-      "name": "Awa Railroad",
-      "abbrev": "AR",
+      "name": "Canadian Northern Railway",
+      "abbrev": "CNR",
+      "color": "green",
+      "tokens": [
+        "Free",
+        "$20/hex",
+        "$40/hex"
+      ],
+      "shares": [
+        {
+          "quantity": 1,
+          "label": "President's Certificate",
+          "percent": 20,
+          "shares": 2
+        },
+        {
+          "quantity": 8,
+          "percent": 10,
+          "shares": 1
+        }
+      ]
+    },
+    {
+      "name": "Canadian Pacific Railway",
+      "abbrev": "CPR",
       "color": "red",
       "tokens": [
         "Free",
-        "¥40"
+        "$20/hex",
+        "$40/hex"
       ],
       "shares": [
         {
@@ -473,34 +339,13 @@
       ]
     },
     {
-      "name": "Iyo Railway",
-      "abbrev": "IR",
-      "color": "orange",
-      "tokens": [
-        "Free",
-        "¥40"
-      ],
-      "shares": [
-        {
-          "quantity": 1,
-          "label": "President's Certificate",
-          "percent": 20,
-          "shares": 2
-        },
-        {
-          "quantity": 8,
-          "percent": 10,
-          "shares": 1
-        }
-      ]
-    },
-    {
-      "name": "Sanuki Railway",
-      "abbrev": "SR",
+      "name": "Chesapeake and Ohio Railway",
+      "abbrev": "C&O",
       "color": "blue",
       "tokens": [
         "Free",
-        "¥40"
+        "$20/hex",
+        "$40/hex"
       ],
       "shares": [
         {
@@ -517,12 +362,13 @@
       ]
     },
     {
-      "name": "Takamatsu & Kotohira Electric Railway",
-      "abbrev": "KO",
-      "color": "pink",
+      "name": "Grand Trunk Railway",
+      "abbrev": "GTR",
+      "color": "orange",
       "tokens": [
         "Free",
-        "¥40"
+        "$20/hex",
+        "$40/hex"
       ],
       "shares": [
         {
@@ -539,13 +385,13 @@
       ]
     },
     {
-      "name": "Tosa Electric Railway",
-      "abbrev": "TR",
-      "color": "darkGreen",
+      "name": "Great Western Railway",
+      "abbrev": "GWR",
+      "color": "brown",
       "tokens": [
         "Free",
-        "¥40",
-        "¥40"
+        "$20/hex",
+        "$40/hex"
       ],
       "shares": [
         {
@@ -562,34 +408,13 @@
       ]
     },
     {
-      "name": "Tosa Kuroshio Railway",
-      "abbrev": "KU",
-      "color": "purple",
-      "tokens": [
-        "Free"
-      ],
-      "shares": [
-        {
-          "quantity": 1,
-          "label": "President's Certificate",
-          "percent": 20,
-          "shares": 2
-        },
-        {
-          "quantity": 8,
-          "percent": 10,
-          "shares": 1
-        }
-      ]
-    },
-    {
-      "name": "Uwajima Railway",
-      "abbrev": "UR",
-      "color": "maroon",
+      "name": "Intercolonial Railway",
+      "abbrev": "CNR",
+      "color": "yellow",
       "tokens": [
         "Free",
-        "¥40",
-        "¥40"
+        "$20/hex",
+        "$40/hex"
       ],
       "shares": [
         {
@@ -604,35 +429,83 @@
           "shares": 1
         }
       ]
+    },
+    {
+      "name": "National Transcontinental Railway",
+      "abbrev": "NTR",
+      "color": "tan",
+      "tokens": [
+        "Free",
+        "$20/hex",
+        "$40/hex"
+      ],
+      "shares": [
+        {
+          "quantity": 1,
+          "label": "President's Certificate",
+          "percent": 20,
+          "shares": 2
+        },
+        {
+          "quantity": 8,
+          "percent": 10,
+          "shares": 1
+        }
+      ]
+    },
+    {
+      "name": "New York Central Railroad",
+      "abbrev": "NYC",
+      "color": "black",
+      "tokens": [
+        "Free",
+        "$20/hex",
+        "$40/hex"
+      ],
+      "shares": [
+        {
+          "quantity": 1,
+          "label": "President's Certificate",
+          "percent": 20,
+          "shares": 2
+        },
+        {
+          "quantity": 8,
+          "percent": 10,
+          "shares": 1
+        }
+      ]
+    },
+    {
+      "name": "Canadian National Railway",
+      "abbrev": "CN",
+      "color": "white",
+      "tokens": ["", "", "", "", "", "", "", ""],
+      "shares": []
     }
   ],
   "phases": [
     {
-      "name": "2",
-      "limit": "4",
-      "number": "6",
-      "tiles": "yellow"
-    },
-    {
       "name": "3",
       "limit": "4",
-      "number": "5",
+      "number": "7",
       "tiles": "green",
-      "notes": "Private companies can be bought"
+      "notes": "May purchase privates"
     },
     {
       "name": "4",
       "rust": "2",
       "limit": "3",
       "number": "4",
-      "tiles": "green"
+      "tiles": "green",
+      "notes": "Public companies may be started"
     },
     {
       "name": "5",
-      "limit": "2",
-      "number": "3",
+      "limit": "3",
+      "number": "4",
       "tiles": "brown",
-      "notes": "Private companies close"
+      "notes": "Remove unstarted Minor Companies"
     },
     {
       "name": "6",
@@ -640,14 +513,33 @@
       "number": "2",
       "rust": "3",
       "tiles": "brown",
-      "notes": "D Trains available for purchase"
+      "notes": "Remaining Private Companies are nationalized"
     },
     {
-      "name": "D",
+      "name": "7",
+      "limit": "2",
+      "number": "2",
+      "tiles": "gray"
+    },
+    {
+      "name": "8",
       "limit": "2",
       "number": "∞",
       "rust": "4",
-      "tiles": "brown"
+      "tiles": "gray",
+      "notes": "5+5E and 2+2 are available"
+    },
+    {
+      "name": "2+2",
+      "limit": "2",
+      "number": "∞",
+      "tiles": "gray"
+    },
+    {
+      "name": "5+5E",
+      "limit": "2",
+      "number": "∞",
+      "tiles": "gray"
     }
   ],
   "privates": [
@@ -655,59 +547,104 @@
       "name": "Champlain & St. Lawrence",
       "price": "Min Bid $20",
       "revenue": "$10",
-      "description": "Face Value $30."
+      "description": "Face Value $30"
     },
     {
-      "name": "Mitsubishi Ferry",
-      "price": "$30",
-      "revenue": "$5",
-      "description": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a company controller by another player. The player need not control a company or have connectivity to the placed tile from one of their companies. This does not close the company."
+      "name": "Niagara Falls Bridge",
+      "price": "Min Bid $30",
+      "revenue": "$15",
+      "description": "Face Value $45, +10 Buffalo"
     },
     {
-      "name": "Ehime Railroad",
-      "price": "¥40",
-      "revenue": "¥10",
-      "description": "When this company is sold to a corporation, the selling player may immediately place a green tile on Ohzu (C4), in addition to any tile which it may lay during the same operating round. This does not close the company."
+      "name": "Montreal Bridge",
+      "price": "Min Bid $40",
+      "revenue": "$20",
+      "description": "Face Value $60, +10 Montreal"
     },
     {
-      "name": "Sumitomo Mines Railway",
-      "price": "¥50",
-      "revenue": "¥15",
-      "description": "Owning corporation may ignore building cost for mountain hexes which do not also contain rivers. This does not close the company."
+      "name": "Quebec Bridge",
+      "price": "Min Bid $50",
+      "revenue": "$25",
+      "description": "Face Value $75, +10 Quebec"
     },
     {
-      "name": "Dougo Railway",
-      "price": "¥60",
-      "revenue": "¥15",
-      "description": "Owning player may exchange this private company for a 10% share of Iyo Railway from the initial offering."
-    },
-    {
-      "name": "South Iyo Railway",
-      "price": "¥80",
-      "revenue": "¥20",
-      "players": "Players: 3+"
-    },
-    {
-      "name": "Uno-Takamatsu Ferry",
-      "price": "¥150",
-      "revenue": "¥30 / ¥50",
-      "players": "Players: 4+",
-      "description": "Does not close while owned by a player. If owned by a player when the first 5-train is purchased it may no longer be sold to a public company and the revenue is increased to 50."
+      "name": "St. Clair Tunnel",
+      "price": "Min Bid $60",
+      "revenue": "$30",
+      "description": "Face Value $90, +10 Detroit"
     }
   ],
   "tiles": {
-    "15": 2,
-    "70": 2,
+    "3": 2,
+    "4": 4,
+    "5": 2,
+    "6": 2,
+    "7": 3,
+    "8": 19,
+    "9": 24,
+    "57": 2,
+    "58": 4,
+    "201": 3,
+    "202": 3,
+    "621": 2,
+
+    "14": 2,
+    "15": 4,
+    "16": 2,
+    "17": 2,
+    "18": 2,
+    "19": 2,
+    "20": 2,
+    "21": 2,
+    "22": 2,
+    "23": 5,
+    "24": 5,
+    "25": 4,
+    "26": 2,
+    "27": 2,
+    "28": 2,
+    "29": 2,
+    "30": 2,
+    "31": 2,
+    "87": 2,
+    "88": 2,
     "120": 1,
-    "122": 1,
-    "124": 1,
+    "204": 2,
+    "207": 5,
+    "208": 2,
+    "619": 2,
+    "622": 2,
+    "624": 1,
+    "625": 1,
+    "626": 1,
+    "637": 1,
     "X1": 1,
     "X2": 1,
     "X3": 1,
     "X4": 1,
+
+    "39": 2,
+    "40": 2,
+    "41": 2,
+    "42": 2,
+    "43": 2,
+    "44": 2,
+    "45": 2,
+    "46": 2,
+    "47": 2,
+    "63": 3,
+    "70": 2,
+    "611": 3,
+    "623": 3,
+    "801": 2,
+    "911": 3,
+    "122": 1,
     "X5": 1,
     "X6": 1,
     "X7": 1,
+
+    "124": 1,
+    "639": 1,
     "X8": 1
   },
   "map": {
@@ -1762,7 +1699,7 @@
           "revenues": [
             {
               "color": "yellow",
-              "cost": "20"
+              "cost": "30"
             },
             {
               "color": "green",

--- a/src/data/tiles/brown.json
+++ b/src/data/tiles/brown.json
@@ -3093,6 +3093,42 @@
       }
     ]
   },
+  "801": {
+    "color": "brown",
+    "values": [
+      {
+        "angle": 215,
+        "percent": 0.8,
+        "value": 50
+      }
+    ],
+    "labels": [
+      {
+        "angle": 270,
+        "percent": 0.9,
+        "label": "Y"
+      }
+    ],
+    "cities": [
+      {
+        "size": 2
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      }
+    ]
+  },
   "803": {
     "color": "brown",
     "values": [
@@ -3152,6 +3188,36 @@
       },
       {
         "side": 2
+      },
+      {
+        "side": 6
+      }
+    ]
+  },
+  "911": {
+    "color": "brown",
+    "centerTowns": [
+      {}
+    ],
+    "values": [
+      {
+        "value": 10,
+        "angle": 150,
+        "percent": 0.8
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5
       },
       {
         "side": 6
@@ -3983,54 +4049,7 @@
       }
     ]
   },
-  "X6": {
-    "color": "brown",
-    "values": [
-      {
-        "angle": -30,
-        "percent": 0.825,
-        "value": 70
-      }
-    ],
-    "labels": [
-      {
-        "label": "M",
-        "angle": 210,
-        "percent": 0.8
-      }
-    ],
-    "cities": [
-      {
-        "rotation": 90,
-        "size": 2,
-        "angle": 90,
-        "percent": 0.2
-      },
-      {
-        "angle": -90,
-        "percent": 0.6
-      }
-    ],
-    "track": [
-      {
-        "side": 1
-      },
-      {
-        "side": 2
-      },
-      {
-        "side": 3
-      },
-      {
-        "side": 4
-      },
-      {
-        "side": 5,
-        "type": "sharp"
-      }
-    ]
-  },
-  "X7": {
+  "X5": {
     "color": "brown",
     "values": [
       {
@@ -4082,7 +4101,54 @@
       }
     ]
   },
-  "X8": {
+  "X6": {
+    "color": "brown",
+    "values": [
+      {
+        "angle": -30,
+        "percent": 0.825,
+        "value": 70
+      }
+    ],
+    "labels": [
+      {
+        "label": "M",
+        "angle": 210,
+        "percent": 0.8
+      }
+    ],
+    "cities": [
+      {
+        "rotation": 90,
+        "size": 2,
+        "angle": 90,
+        "percent": 0.2
+      },
+      {
+        "angle": -90,
+        "percent": 0.6
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5,
+        "type": "sharp"
+      }
+    ]
+  },
+  "X7": {
     "color": "brown",
     "values": [
       {

--- a/src/data/tiles/gray.json
+++ b/src/data/tiles/gray.json
@@ -542,6 +542,55 @@
       }
     ]
   },
+  "639": {
+    "color": "gray",
+    "values": [
+      {
+        "angle": 270,
+        "percent": 0.87,
+        "value": 100
+      }
+    ],
+    "labels": [
+      {
+        "label": "M",
+        "angle": 205,
+        "percent": 0.84
+      }
+    ],
+    "cities": [
+      {
+        "size": 4,
+        "percent": 0.1,
+        "companies": [
+          {
+            "label": "CN",
+            "color": "white"
+          }
+        ]
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5
+      },
+      {
+        "side": 6
+      }
+    ]
+  },
   "805": {
     "color": "gray",
     "values": [
@@ -1380,6 +1429,50 @@
       {
         "size": 4,
         "percent": 0.1
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5
+      },
+      {
+        "side": 6
+      }
+    ]
+  },
+  "X8": {
+    "color": "gray",
+    "rotations": 1,
+    "cities": [
+      {
+        "size": 3,
+        "rotate": 180
+      }
+    ],
+    "values": [
+      {
+        "angle": 270,
+        "percent": 0.88,
+        "value": 60
+      }
+    ],
+    "labels": [
+      {
+        "label": "O",
+        "angle": 205,
+        "percent": 0.84
       }
     ],
     "track": [

--- a/src/data/tiles/green.json
+++ b/src/data/tiles/green.json
@@ -772,6 +772,33 @@
       }
     ]
   },
+  "204": {
+    "color": "green",
+    "centerTowns": [
+      {}
+    ],
+    "values": [
+      {
+        "value": 10,
+        "angle": 60,
+        "percent": 0.5
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5
+      }
+    ]
+  },
   "205": {
     "color": "green",
     "values": [
@@ -817,6 +844,79 @@
       },
       {
         "side": 4
+      }
+    ]
+  },
+  "207": {
+    "color": "green",
+    "values": [
+      {
+        "angle": 210,
+        "percent": 0.8,
+        "value": 40
+      }
+    ],
+    "labels": [
+      {
+        "label": "Y",
+        "angle": 155,
+        "percent": 0.75
+      }
+    ],
+    "cities": [
+      {
+        "size": 2
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 3
+      },
+      {
+        "side": 4
+      }
+    ]
+  },
+  "208": {
+    "color": "green",
+    "rotations": 3,
+    "values": [
+      {
+        "angle": 210,
+        "percent": 0.8,
+        "value": 40
+      }
+    ],
+    "labels": [
+      {
+        "label": "Y",
+        "angle": 155,
+        "percent": 0.75
+      }
+    ],
+    "cities": [
+      {
+        "size": 2
+      }
+    ],
+    "track": [
+      {
+        "side": 1
+      },
+      {
+        "side": 2
+      },
+      {
+        "side": 4
+      },
+      {
+        "side": 5
       }
     ]
   },
@@ -1837,6 +1937,55 @@
       {
         "type": "sharp",
         "side": 5
+      }
+    ]
+  },
+  "637": {
+    "color": "green",
+    "rotations": 6,
+    "values": [
+      {
+        "angle": -30,
+        "percent": 0.7,
+        "value": 50
+      }
+    ],
+    "labels": [
+      {
+        "angle": 210,
+        "percent": 0.8,
+        "label": "M"
+      }
+    ],
+    "cities": [
+      {
+        "angle": 30,
+        "percent": 0.5
+      },
+      {
+        "angle": 150,
+        "percent": 0.5
+      },
+      {
+        "angle": 270,
+        "percent": 0.5
+      }
+    ],
+    "track": [
+      {
+        "type": "sharp",
+        "side": 1,
+        "cross": "over"
+      },
+      {
+        "type": "sharp",
+        "side": 5,
+        "cross": "under"
+      },
+      {
+        "type": "sharp",
+        "side": 3,
+        "cross": "under"
       }
     ]
   },
@@ -4870,55 +5019,6 @@
       {
         "type": "sharp",
         "side": 5,
-        "cross": "under"
-      }
-    ]
-  },
-  "X5": {
-    "color": "green",
-    "rotations": 6,
-    "values": [
-      {
-        "angle": -30,
-        "percent": 0.7,
-        "value": 50
-      }
-    ],
-    "labels": [
-      {
-        "angle": 210,
-        "percent": 0.8,
-        "label": "M"
-      }
-    ],
-    "cities": [
-      {
-        "angle": 30,
-        "percent": 0.5
-      },
-      {
-        "angle": 150,
-        "percent": 0.5
-      },
-      {
-        "angle": 270,
-        "percent": 0.5
-      }
-    ],
-    "track": [
-      {
-        "type": "sharp",
-        "side": 1,
-        "cross": "over"
-      },
-      {
-        "type": "sharp",
-        "side": 5,
-        "cross": "under"
-      },
-      {
-        "type": "sharp",
-        "side": 3,
         "cross": "under"
       }
     ]

--- a/src/data/tiles/yellow.json
+++ b/src/data/tiles/yellow.json
@@ -957,6 +957,32 @@
       }
     ]
   },
+  "621": {
+    "color": "yellow",
+    "rotations": 3,
+    "values": [
+      {
+        "angle": 210,
+        "percent": 0.75,
+        "value": 30
+      }
+    ],
+    "labels": [
+      {
+        "label": "Y",
+        "angle": 155,
+        "percent": 0.75
+      }
+    ],
+    "cities": [
+      {}
+    ],
+    "track": [
+      {
+        "type": "straight"
+      }
+    ]
+  },
   "630": {
     "color": "yellow",
     "values": [


### PR DESCRIPTION
 * Update 1867 as follows:
   * Add subtitle.
   * Fix bank, rounds, turns.
   * Start fixing stock market (not done).
   * Fix trains.
   * Define all public and private companies. (Minor companies not done yet).
   * Fix tile manifest.
   * Update yellow value for Maritime Provinces.
* Update tile manifest
  * Add yellow tile 621.
  * Add green tiles 204, 207, 637.
  * Remove green tile X5 (it should be brown).
  * Add brown tiles 801, 911.
  * Rename brown tile X7 to X5.
  * Rename brown tile X8 to X7.
  * Add gray tiles 639, X8.