### PR TITLE
Value's size accords to the value's length

### DIFF
--- a/src/atoms/Value.jsx
+++ b/src/atoms/Value.jsx
@@ -5,7 +5,7 @@ import RotateContext from "../context/RotateContext";
 
 const Value = ({ value, fixed, outerBorderColor }) => {
   let size = 15;
-  if (value > 99) {
+  if (value.toString().length > 2) {
     size = 13;
   }
 


### PR DESCRIPTION
I wanted to have a "+10" value and I realised that it didn't scale.