### PR TITLE
Add display elements for minimum bids

### DIFF
--- a/src/cards/Private.jsx
+++ b/src/cards/Private.jsx
@@ -1,13 +1,15 @@
 import React from "react";
 
-const Private = ({ name, price, revenue, icon, players, description }) => {
+const Private = ({ name, price, revenue, bid, icon, players, description }) => {
   return (
     <div className="cutlines">
       <div className="card private">
         {icon && <div className="private__icon">{icon}</div>}
         <div className="private__name">{name}</div>
         <div className="private__description">{description}</div>
+        {bid && <div className="private__bid">Min Bid: {bid}</div>}
         <div className="private__price">{price}</div>
+        {players && <div className="private__players">{players}</div>}
         {players && <div className="private__players">{players}</div>}
         {revenue && <div className="private__revenue">Revenue: {revenue}</div>}
       </div>

--- a/src/data/games/1867.json
+++ b/src/data/games/1867.json
@@ -657,33 +657,38 @@
   "privates": [
     {
       "name": "Champlain & St. Lawrence",
-      "price": "Min Bid $20",
+      "price": "Face: $30",
       "revenue": "$10",
-      "description": "Face Value $30"
+      "bid": "$20",
+      "description": ""
     },
     {
       "name": "Niagara Falls Bridge",
-      "price": "Min Bid $30",
+      "price": "Face: $45",
       "revenue": "$15",
-      "description": "Face Value $45, +10 Buffalo"
+      "bid": "$30",
+      "description": "+10 Buffalo"
     },
     {
       "name": "Montreal Bridge",
-      "price": "Min Bid $40",
+      "price": "Face: $60",
       "revenue": "$20",
-      "description": "Face Value $60, +10 Montreal"
+      "bid": "$40",
+      "description": "+10 Montreal"
     },
     {
       "name": "Quebec Bridge",
-      "price": "Min Bid $50",
+      "price": "Face: $75",
       "revenue": "$25",
-      "description": "Face Value $75, +10 Quebec"
+      "bid": "$50",
+      "description": "+10 Quebec"
     },
     {
       "name": "St. Clair Tunnel",
-      "price": "Min Bid $60",
+      "price": "Face: $90",
       "revenue": "$30",
-      "description": "Face Value $90, +10 Detroit"
+      "bid": "$60",
+      "description": "+10 Detroit"
     }
   ],
   "tiles": {

--- a/src/index.css
+++ b/src/index.css
@@ -664,6 +664,17 @@ svg {
   font-size: 0.18in;
 }
 
+.private__bid {
+  position: absolute;
+  bottom: 0.25in;
+  left: 0;
+  margin: 0.125in;
+  padding: 0.125in;
+  height: 0.25in;
+  line-height: 0.25in;
+  font-size: 0.18in;
+}
+
 .private__players {
   position: absolute;
   bottom: 0.25in;


### PR DESCRIPTION
Privates for 1867 have a minimum bid in addition to a price (face value). This extends the Private class to render a minimum bid above the price.