### PR TITLE
1834 update map

### DIFF
--- a/src/data/games/1834.json
+++ b/src/data/games/1834.json
@@ -949,7 +949,7 @@
         "cities": [
           {
             "name": {
-              "name": "Luxembourge",
+              "name": "Luxembourg",
               "reverse": true,
               "rotation": -90
             },
@@ -1001,13 +1001,6 @@
       },
       {
         "color": "yellow",
-        "labels": [
-          {
-            "angle": 150,
-            "percent": 0.7,
-            "label": "B"
-          }
-        ],
         "cities": [
           {
             "name": {
@@ -1057,31 +1050,12 @@
       },
       {
         "color": "water",
-        "offBoardRevenue": {
-          "name": {
-            "name": "Port",
-            "bgColor": "water"
-          },
-          "revenues": [
-            {
-              "cost": "10",
-              "color": "yellow"
-            },
-            {
-              "cost": "30",
-              "color": "brown"
-            }
-          ]
-        },
+        "removeBorders": [
+          6
+        ],
         "offBoardTrack": [
           {
             "side": 6
-          }
-        ],
-        "icons": [
-          {
-            "type": "port",
-            "percent": 0.5
           }
         ],
         "hexes": [
@@ -1093,10 +1067,11 @@
         "icons": [
           {
             "type": "port",
-            "percent": 0.5
+            "percent": -0.5
           }
         ],
         "offBoardRevenue": {
+          "percent": -1,
           "name": {
             "name": "Port",
             "bgColor": "water"
@@ -1112,6 +1087,9 @@
             }
           ]
         },
+        "removeBorders": [
+          4
+        ],
         "offBoardTrack": [
           {
             "side": 5
@@ -1184,7 +1162,7 @@
         "color": "offboard",
         "divides": [
           {
-            "side": 3.25
+            "side": 3
           }
         ],
         "offBoardRevenue": {
@@ -1251,21 +1229,9 @@
       },
       {
         "color": "offboard",
-        "offBoardRevenue": {
-          "name": {
-            "name": "Aachen"
-          },
-          "revenues": [
-            {
-              "cost": "20",
-              "color": "yellow"
-            },
-            {
-              "cost": "50",
-              "color": "brown"
-            }
-          ]
-        },
+        "removeBorders": [
+          6
+        ],
         "offBoardTrack": [
           {
             "side": 1
@@ -1278,6 +1244,8 @@
       {
         "color": "offboard",
         "offBoardRevenue": {
+          "angle": 120,
+          "percent": 1,
           "name": {
             "name": "Aachen"
           },
@@ -1292,6 +1260,9 @@
             }
           ]
         },
+        "removeBorders": [
+          3
+        ],
         "offBoardTrack": [
           {
             "side": 2

--- a/src/data/games/1834.json
+++ b/src/data/games/1834.json
@@ -950,8 +950,7 @@
           {
             "name": {
               "name": "Luxembourg",
-              "reverse": true,
-              "rotation": -90
+              "reverse": true
             },
             "companies": [
               {
@@ -978,8 +977,7 @@
           {
             "name": {
               "name": "Ghent",
-              "reverse": true,
-              "rotation": -90
+              "rotation": 40
             }
           }
         ],


### PR DESCRIPTION
I updated the the 1834 map:
- merged same offboard connections
- removed "B" label from Antwerp
- removed "e" from "Luxembourge"
- adjusted placement of city names so it's somehow coherent