### PR TITLE
Add formatCell to train prices in Phase.jsx.

### DIFF
--- a/src/Phase.jsx
+++ b/src/Phase.jsx
@@ -67,7 +67,7 @@ const Phase = ({ phases }) => {
             {includeName && <td>{phase.name}</td>}
             {includePhase && <td>{phase.phase}</td>}
             {includeTrain && <td>{formatCell(phase.train)}</td>}
-            {includePrice && <td>{phase.price}</td>}
+            {includePrice && <td>{formatCell(phase.price)}</td>}
             <td>{formatCell(phase.number)}</td>
             <td>{phase.limit}</td>
             {!excludeTiles && <td style={{ backgroundColor: c(phase.tiles) }}>&nbsp;</td>}


### PR DESCRIPTION
This allows for multiple rows in a cell in the train price column in the phases table. 