### PR TITLE
Change Burbach Foundry icon

### DIFF
--- a/src/data/games/1834.json
+++ b/src/data/games/1834.json
@@ -194,7 +194,7 @@
       "name": "Burbach Foundry",
       "price": 70,
       "revenue": 15,
-      "tile": "27",
+      "tile": "53",
       "description": "Owning corporation may upgrade an additional track tile in a Luxembourg city tile (hexes N11 and M10), from YELLOW to GREEN. This is in addition to its normal placement and closes the private. Can be sold in the GREEN phase."
     },
     {


### PR DESCRIPTION
Very minor tweak - I changed the Burbach Foundry icon to the tile which is more iconic. Looks better to my eye.