### PR TITLE
Add small card identifier text to bottom right of cards.

### DIFF
--- a/src/Charter.jsx
+++ b/src/Charter.jsx
@@ -11,7 +11,22 @@ import Currency from "./util/Currency";
 
 import is from "ramda/src/is";
 
-const Charter = ({ name, abbrev, logo, minor, token, tokens, phases, turns, charterStyle, game, halfWidthCharters, company, blackBand }) => {
+const Charter = ({
+  name,
+  abbrev,
+  logo,
+  minor,
+  token,
+  tokens,
+  phases,
+  turns,
+  charterStyle,
+  game,
+  halfWidthCharters,
+  company,
+  blackBand,
+  card_identifier
+}) => {
   let color = token;
   if(is(Object, token)) {
     color = token.colors[0];
@@ -119,6 +134,7 @@ const Charter = ({ name, abbrev, logo, minor, token, tokens, phases, turns, char
                     <dl>{minor || turnNodes}</dl>
                   </div>
                 )}
+                <div className="card__identifier">{card_identifier}</div>
               </div>
             </div>
           </div>

--- a/src/Charters.jsx
+++ b/src/Charters.jsx
@@ -168,6 +168,7 @@ const Charters = ({charters, paper, override, selection}) => {
               turns={game.turns}
               minor={!!company.minor}
               company={company}
+              card_identifier={company.card_identifier}
             /> : <div key="spacer" className={`cutlines${charters.halfWidth ? " cutlines--half" : ""}`}><div className={`charter${charters.halfWidth ? " charter--half" : ""}`}></div></div>
         ), companies)}
         <PageSetup landscape={false}/>

--- a/src/cards/Private.jsx
+++ b/src/cards/Private.jsx
@@ -17,7 +17,21 @@ import { getMapHex } from "../map/util";
 
 import "./private.scss";
 
-const Private = ({ name, note, price, revenue, bid, players, description, icon, hex, tile, token, company }) => {
+const Private = ({
+  name,
+  note,
+  price,
+  revenue,
+  bid,
+  players,
+  description,
+  icon,
+  hex,
+  tile,
+  token,
+  company,
+  card_identifier
+}) => {
   let revenueNode = null;
   if (is(Array, revenue)) {
     revenueNode = intersperse("/", map(r => <Currency value={r} type="private" />, revenue));
@@ -74,6 +88,7 @@ const Private = ({ name, note, price, revenue, bid, players, description, icon, 
             <div className="private__price"><Currency value={price} type="private"/></div>
             {players && <div className="private__players">{players}</div>}
             {revenueNode && <div className="private__revenue">Revenue: {revenueNode}</div>}
+            <div className="card__identifier">{card_identifier}</div>
           </div>
         </div>
       </div>

--- a/src/cards/Share.jsx
+++ b/src/cards/Share.jsx
@@ -24,7 +24,8 @@ const LeftShare = ({
   shareStyle,
   company,
   tokenCount,
-  blackBand
+  blackBand,
+  card_identifier
 }) => {
   let count = shares > 1 ? `${shares} Shares` : `${shares} Share`;
 
@@ -104,6 +105,7 @@ const LeftShare = ({
                  </Color>
                </div>
              )}
+             <div className="card__identifier">{card_identifier}</div>
           </div>
         </div>
       </div>
@@ -122,7 +124,8 @@ const CenterShare = ({
   abbrev,
   token,
   company,
-  tokenCount
+  tokenCount,
+  card_identifier
 }) => {
   let count = shares > 1 ? `${shares} Shares` : `${shares} Share`;
 
@@ -173,6 +176,7 @@ const CenterShare = ({
                  </Color>
                </div>
              )}
+             <div className="card__identifier">{card_identifier}</div>
           </div>
         </div>
       </div>

--- a/src/cards/Train.jsx
+++ b/src/cards/Train.jsx
@@ -15,7 +15,7 @@ import brownTrain from "../images/brown-train.png";
 import grayTrain from "../images/gray-train.png";
 
 const Train = ({ train, blackBand }) => {
-  let { name, price, color, info, description, players } = train;
+  let { name, price, color, info, description, players, card_identifier } = train;
 
   let notes = addIndex(map)(
     (i, index) => (
@@ -86,6 +86,7 @@ const Train = ({ train, blackBand }) => {
                     </div>
                     {description && <div className="train__description">{description}</div>}
                     <div className="train__notes">{notes}</div>
+                    <div className="card__identifier">{card_identifier}</div>
                   </div>
                 </div>
               </div>

--- a/src/cards/card.scss
+++ b/src/cards/card.scss
@@ -43,3 +43,12 @@
   top: 0;
   left: 0;
 }
+
+.card__identifier {
+  position: absolute;
+  bottom: 0.3em;
+  right: 0.3em;
+  font-size: 0.5em;
+  font-style: italic;
+  font-family: sans-serif;
+}

--- a/src/data/schemas/game.schema.json
+++ b/src/data/schemas/game.schema.json
@@ -46,7 +46,8 @@
           "cost": { "type": "number", "minimum": 0 },
           "percent": { "$ref": "#/definitions/numberOrSlash" },
           "revenue": { "$ref": "#/definitions/numberOrSlash" },
-          "shares": { "$ref": "#/definitions/numberOrSlash" }
+          "shares": { "$ref": "#/definitions/numberOrSlash" },
+          "card_identifier": { "type": "string" }
         },
         "required": ["quantity"]
       }
@@ -126,6 +127,7 @@
         "required": ["name", "abbrev"],
         "properties": {
           "name": { "type": "string" },
+          "card_identifier": { "type": "string" },
           "shares": {
             "oneOf": [
               { "$ref" : "#/definitions/shares" },
@@ -172,6 +174,7 @@
           "company": { "type": "string" },
           "icon": { "type": "string" },
           "tile": { "type": "string" },
+          "card_identifier": { "type": "string" },
           "bid": {
             "oneOf": [
               { "type": "string" },
@@ -207,7 +210,16 @@
     "tiles": {},
     "tokens": {},
     "turns": {},
-    "trains": {},
+    "trains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "card_identifier": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
     "wip": { "type": "boolean" }
   },
   "additionalProperties": false,


### PR DESCRIPTION
- Had an attempt at updating game.schema.json, after a quick skim of the JSON schema docs. Feel free to disregard this file or correct it if it's wrong.

- The "centre" share style needs styling adjustments if the card identifier is shown, as the text of the share percentage is too close. The number of shares and the percentage need more bottom padding. If you make this the same as the left/gmt variants, then it works, but might be too close to the horizontally coloured line. There looks like some simple adjustments that would allow the left/gmt variant to be removed entirely, but I'm unfamiliar with any ramifications this might cause, so have only made minimal stylistic changes.

- The card identifier styling might need adjustments, particularly with respect to how close it prints to the cut lines. I'm not currently able to test any printing. Feel free to adjust the styles as per any guides or designs you have in mind.

- This identifier might be able to be used to replace your player count details.

- Feel free to change the code to:
`{card_identifier && <div className="card__identifier">{card_identifier}</div>}` if this is preferred.