### PR TITLE
Add ability to hide revenue table; custom pool height

### DIFF
--- a/src/Config.jsx
+++ b/src/Config.jsx
@@ -289,6 +289,9 @@ const Config = ({config, setConfig, resetConfig}) => {
       <h3>IPO</h3>
       <Input name="ipo.borderRadius" label="IPO Border Radius" dimension={true}
              description="How much to round the corners, zero will disable rounded corners on the IPO cards" />
+      <h3>Revenue Table</h3>
+      <Input name="revenueTable.visible" label="Show revenue table"
+             description="Whether or not to render the revenue table. If you use your own revenue tracker, you may wish to print only the market and player info." />
       <h3>Currency</h3>
       <p>This lets you turn on currency symbols for each item individually. Only works if the game file specificies values as numbers and not strings.</p>
       <Input name="currency.bank" label="Bank" description="Bank total on revenue page"/>

--- a/src/Pool.jsx
+++ b/src/Pool.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as R from "ramda";
 import Color from "./data/Color";
 
-const Pool = ({ name, notes }) => {
+const Pool = ({ name, notes, height }) => {
   let notesNode = null;
 
   if (notes && notes.length > 0) {
@@ -30,7 +30,7 @@ const Pool = ({ name, notes }) => {
   return (
     <div className="pool">
       <h2>{name}</h2>
-      <div className="pool__box">{notesNode}</div>
+      <div className="pool__box" style={{ height: height}}>{notesNode}</div>
     </div>
   );
 };

--- a/src/Revenue.jsx
+++ b/src/Revenue.jsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import * as R from "ramda";
 import Color from "./data/Color";
 import games from "./data/games";
+import Config from "./data/Config";
 
 import Pool from "./Pool";
 import Players from "./Players";
@@ -45,7 +46,7 @@ const generateCells = (rows, cols) => {
 const Revenue = () => {
   let params = useParams();
   let game = games[params.game];
-
+  
   let rows = Array.from(Array(5).keys());
   let cols = Array.from(Array(20).keys());
 
@@ -59,12 +60,21 @@ const Revenue = () => {
           <p>Revenue is meant to be printed in <b>landscape</b> mode</p>
         </div>
       </div>
-      <div className="revenue__tracker">
-        <h2>{game.info.title} Revenue</h2>
-        <table className="revenue__table">
-          <tbody>{items}</tbody>
-        </table>
-      </div>
+      <Config>
+        {config => {
+          if (config.revenueTable.visible === false) {
+            return null;
+          }
+          return (
+            <div className="revenue__tracker">
+              <h2>{game.info.title} Revenue</h2>
+              <table className="revenue__table">
+                <tbody>{items}</tbody>
+              </table>
+            </div>
+          )
+        }}
+      </Config>
       <div className="pool-wrapper">
         {pools}
         <Players players={game.players} bank={game.bank} capital={game.capital} />

--- a/src/config.json
+++ b/src/config.json
@@ -86,5 +86,8 @@
       "width": 200,
       "height": 85
     }
+  },
+  "revenueTable": {
+    "visible": true
   }
 }

--- a/src/data/games/18Test.json
+++ b/src/data/games/18Test.json
@@ -364,6 +364,7 @@
   "pools": [
     {
       "name": "Market",
+      "height": "5in",
       "notes": [
         {
           "color": "orange",

--- a/src/data/schemas/config.schema.json
+++ b/src/data/schemas/config.schema.json
@@ -188,7 +188,15 @@
     },
     "plainMapCompanies": { "type": "boolean" },
     "straightCityNames": { "type": "boolean" },
-    "font": { "$ref": "#/definitions/font" }
+    "font": { "$ref": "#/definitions/font" },
+    "revenueTable": { 
+      "type": "object",
+      "properties": {
+        "visible": { "type": "boolean" }
+      },
+      "additionalProperties": false,
+      "required": ["visible"]
+    }
   },
   "required": [
     "companiesTheme",

--- a/src/data/schemas/game.schema.json
+++ b/src/data/schemas/game.schema.json
@@ -164,7 +164,30 @@
         "required": ["number"]
       }
     },
-    "pools": {},
+    "pools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "height": { 
+            "type": "string",
+            "description": "A valid CSS height value"
+          },
+          "notes": { 
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "color": { "type": "string" },
+                "icon": { "type": "string" },
+                "note": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
     "privates": {
       "type": "array",
       "items": {


### PR DESCRIPTION
- First commit adds an option to hide the revenue table. I already have a revenue table that provides more benefits, but I'd still like to print the market and player info.

- Second commit adds an option to define custom heights for the pools. This is helpful when the revenue table is hidden, and you'd like a larger market.
