### PR TITLE
Add train trade in pricing.

### DIFF
--- a/src/cards/Train.jsx
+++ b/src/cards/Train.jsx
@@ -15,7 +15,16 @@ import brownTrain from "../images/brown-train.png";
 import grayTrain from "../images/gray-train.png";
 
 const Train = ({ train, blackBand }) => {
-  let { name, price, color, info, description, players, backgroundColor, variant } = train;
+  let { 
+    name, 
+    price, 
+    tradeInPrice,
+    color, 
+    info, 
+    description, 
+    players, 
+    backgroundColor, 
+    variant } = train;
 
   let notes = addIndex(map)(
     (i, index) => (
@@ -86,6 +95,11 @@ const Train = ({ train, blackBand }) => {
                          style={{ backgroundColor: config.trains.style === "color" ? c(color) : null,
                                   color: config.trains.style === "color" ? t(c(color)) : c(color) }}>
                       <Currency value={price} type="train"/>
+                      {tradeInPrice && (
+                        <div className="train__trade_in_price">
+                          (<Currency value={tradeInPrice} type="train"/>)
+                        </div>
+                      )}
                     </div>
                     {description && <div className="train__description">{description}</div>}
                     <div className="train__notes">{notes}</div>

--- a/src/cards/train.scss
+++ b/src/cards/train.scss
@@ -31,6 +31,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: flex-end;
+  flex-direction: column;
 }
 
 .train__tracks {
@@ -123,4 +124,9 @@
   font-size: 0.5em;
   font-style: italic;
   font-family: sans-serif;
+}
+
+.train__trade_in_price {
+  font-size: 0.6em;
+  padding-top: 0.2em;
 }

--- a/src/data/games/18Test.json
+++ b/src/data/games/18Test.json
@@ -248,6 +248,7 @@
       "name": "8E",
       "quantity": 2,
       "price": "$1100",
+      "tradeInPrice": 900,
       "color": "gray",
       "info": [
         {

--- a/src/data/schemas/game.schema.json
+++ b/src/data/schemas/game.schema.json
@@ -221,6 +221,7 @@
       "items": {
         "type": "object",
         "properties": {
+          "tradeInPrice": { "type": "number"},
           "variant": { "type": "string" }
         },
         "additionalProperties": true


### PR DESCRIPTION
This adds a new property `tradeInPrice` to the train JSON element that provides for a trade in price. It will display under the train price in parenthesis, and a slightly smaller font. This can be used with the `description` property to provide more detail.

I've updated the game schema, but it's not 100% correct. Instead of it being a number, it should be whatever the `Currency` component takes. I'm not sure how to define the `type` as `whatever the Currency component takes`, so if that's possible, please advise or make the change yourself.

18Test has been updated with an example of usage.