### PR TITLE
Possibility to set terrain cost's color

### DIFF
--- a/src/atoms/Terrain.jsx
+++ b/src/atoms/Terrain.jsx
@@ -3,7 +3,7 @@ import Color from "../data/Color";
 
 import Currency from "../util/Currency";
 
-const Terrain = ({ type, size, cost, fontSize }) => {
+const Terrain = ({ type, size, cost, fontSize, color }) => {
   fontSize = fontSize || 15;
 
   let translate = 0;
@@ -43,7 +43,7 @@ const Terrain = ({ type, size, cost, fontSize }) => {
             <use href={`#${type}`} />
           </g>
           <text
-            fill={p("black")}
+            fill={p(color || "black")}
             fontSize={fontSize}
             dominantBaseline="hanging"
             textAnchor="middle"

--- a/src/atoms/index.jsx
+++ b/src/atoms/index.jsx
@@ -243,7 +243,7 @@ const atoms = [{
     {terrain: [{type:"mountain",cost:"$100"}]},
     {terrain: [{type:"water",cost:"$40"}]},
     {terrain: [{type:"river",cost:"$20"}]},
-    {terrain: [{type:"tree",cost:"$20"}]},
+    {terrain: [{type:"tree",cost:"$20",color:"green"}]},
     {terrain: [{type:"cactus",cost:"$20"}]},
     {terrain: [{size:"tiny",type:"river",cost:"$10"}]},
     {terrain: [{size:"large",type:"swamp",cost:"$120"}]}


### PR DESCRIPTION
Something I needed and might be useful to others as well.

Usage:
```
{
"terrain": [
 {
    "type": "tree",
    "cost": "$20",
    "color": "green"
 }
```

Updated atom examples.