### PR TITLE
1832 map fixes

### DIFF
--- a/src/data/games/1832.json
+++ b/src/data/games/1832.json
@@ -1253,7 +1253,7 @@
             },
             {
               "color": "brown",
-              "cost": "50"
+              "cost": "60"
             }
           ]
         },
@@ -1265,6 +1265,13 @@
         ],
         "centerTowns": [
           {}
+        ],
+        "terrain": [
+          {
+            "angle": -70,
+            "percent": 0.667,
+            "cost": 80
+          }
         ],
         "hexes": [
           "B14"
@@ -1339,7 +1346,7 @@
             },
             {
               "color": "brown",
-              "cost": "30"
+              "cost": "40"
             },
             {
               "color": "gray",


### PR DESCRIPTION
Two revenue locations to fix, plus I think it is better to have the cost for the coal fields printed on the hex.

<img width="329" alt="Screenshot 2020-01-27 09 23 17" src="https://user-images.githubusercontent.com/1414428/73197769-c16ca500-40e6-11ea-8843-20680b96fc84.png">

<img width="322" alt="Screenshot 2020-01-27 09 23 11" src="https://user-images.githubusercontent.com/1414428/73197794-cc273a00-40e6-11ea-8a9c-71422d432dbe.png">
