### PR TITLE
Fixed an issue with hex base color bleeding past the default border.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,7 @@ const App = () => (
             </marker>
             <mask id="hexMask">
               <rect x="-100" y="-100" width="200" height="200" fill="black"/>
-              <polygon points="-86.6025,0 -43.30125,-75 43.30125,-75 86.6025,0 43.30125,75 -43.30125,75"
+              <polygon points="-86.0252,0 -43.0126,-74.5 43.0126,-74.5 86.0252,0 43.0126,74.5 -43.0126,74.5"
                        fill="white"
                        stroke="white"
                        strokeWidth="2" />


### PR DESCRIPTION
Mask width 75 comes right to the outer edge of the border, creating pixelwide artifacts on the outer edge. Mask width 74 comes right to the middle of the border, creating pixelwide artifacts on borderless edges. Mask width 74.5 appears to solve both issues.

These probably don't show up when printing, but are quite visible when viewing a pdf in the browser.